### PR TITLE
✨ feat : 유저 온보딩 기능 구현

### DIFF
--- a/src/main/java/com/pinHouse/server/core/config/RedisConfig.java
+++ b/src/main/java/com/pinHouse/server/core/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.pinHouse.server.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig{
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    /**
+     * 레디스 커넥트 팩토리 설정
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    /**
+     * 레디스 템플릿 설정
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+
+}

--- a/src/main/java/com/pinHouse/server/core/response/response/ErrorCode.java
+++ b/src/main/java/com/pinHouse/server/core/response/response/ErrorCode.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 /**
  * 애플리케이션 전역에서 사용하는 에러 코드 Enum입니다.
  * 각 에러는 고유 코드, HTTP 상태, 메시지를 포함합니다.
- *
  * 0~999 : 공통 에러
  * 1000~1999 : 유저 관련 에러
  * 2000~2999 : 영화관 관련 에러
@@ -34,7 +33,9 @@ public enum ErrorCode {
     NULL_VALUE(400_003, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
     TEST_ERROR(400_004, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
     BAD_REQUEST_PINPOINT(400_005, HttpStatus.BAD_REQUEST, "핀포인트와 유저가 일치하지않습니다."),
-
+    INVALID_INPUT_ENUM(400_006, HttpStatus.BAD_REQUEST, "Enum의 입력값이 올바르지 않습니다."),
+    BAD_OAUTH2(400_007, HttpStatus.BAD_REQUEST, "Provider가 적절하지 않습니다"),
+    INTERNAL_LOGIN_SERVER_ERROR(400_008, HttpStatus.BAD_REQUEST, "회원가입 온보딩 중 오류가 발생했습니다."),
 
     // ========================
     // 401 Unauthorized
@@ -55,8 +56,6 @@ public enum ErrorCode {
     UNSUPPORTED_SOCIAL_LOGIN(401_012, HttpStatus.UNAUTHORIZED, "지원하지 않는 소셜 로그인 방식입니다."),
 
 
-
-
     // ========================
     // 403 Forbidden
     // ========================
@@ -75,7 +74,7 @@ public enum ErrorCode {
     POST_TYPE_NOT_FOUND(404_004, HttpStatus.NOT_FOUND, "게시글 타입을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(404_005, HttpStatus.NOT_FOUND, "요청한 댓글을 찾을 수 없습니다."),
     PRODUCT_NOT_FOUND(404_006, HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
-    NOT_NOTICE(404_007,HttpStatus.NOT_FOUND,"해당 공고를 찾을 수 없습니다"),
+    NOT_NOTICE(404_007, HttpStatus.NOT_FOUND, "해당 공고를 찾을 수 없습니다"),
     NOT_PINPOINT(404_008, HttpStatus.NOT_FOUND, "해당 핀포인트를 찾을 수 없습니다"),
 
     // ========================
@@ -83,23 +82,30 @@ public enum ErrorCode {
     // ========================
     DUPLICATE_EMAIL(409_001, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     BOOKMARK_NOT_OWN_USER(409_002, HttpStatus.CONFLICT, "유저가 추가한 북마크가 아닙니다."),
-    BOOKMARK_ALREADY(409_003,HttpStatus.CONFLICT,"이미 해당 상품에 북마크를 등록했습니다"),
+    BOOKMARK_ALREADY(409_003, HttpStatus.CONFLICT, "이미 해당 상품에 북마크를 등록했습니다"),
 
 
     // ========================
     // 500 Internal Server Error
     // ========================
     INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),;
+    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
+    ;
 
 
-    /** 에러 코드 (고유값) */
+    /**
+     * 에러 코드 (고유값)
+     */
     private final Integer code;
 
-    /** HTTP 상태 코드 */
+    /**
+     * HTTP 상태 코드
+     */
     private final HttpStatus httpStatus;
 
-    /** 에러 메시지 */
+    /**
+     * 에러 메시지
+     */
     private final String message;
 
 

--- a/src/main/java/com/pinHouse/server/core/util/RedisKeyUtil.java
+++ b/src/main/java/com/pinHouse/server/core/util/RedisKeyUtil.java
@@ -1,0 +1,32 @@
+package com.pinHouse.server.core.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class RedisKeyUtil {
+
+    /// 개별 키 목록
+    private static final String OAUTH2_TEMP_USER = "OAUTH2_TEMP_USER:";
+    private static final String SEPARATOR = ":";
+    private static final String LIST = "list";
+    private static final String BEST = "best";
+    private static final String AUDITORIUM = "auditorium";
+    private static final String REVIEW = "review";
+    private static final String RECENT_SEARCH_PREFIX = "recentSearch:guest:";
+    private static final String SUMMARY = "Summary";
+
+    /// 합쳐서 사용하는 키 목록
+    private static final String BEST_AUDITORIUM_LIST_KEY = BEST + SEPARATOR + AUDITORIUM + SEPARATOR + LIST;
+    private static final String BEST_REVIEW_LIST_KEY = BEST + SEPARATOR + REVIEW + SEPARATOR + LIST;
+    private static final String REVIEW_SUMMARY_KEY = REVIEW + SUMMARY;
+
+    /// 키 생성 함수
+    public String generateOAuth2TempUserKey() {
+        return OAUTH2_TEMP_USER + UUID.randomUUID();
+    }
+    public  String getGuestRecentSearchKey(String guestToken) { return RECENT_SEARCH_PREFIX + guestToken; }
+
+
+}

--- a/src/main/java/com/pinHouse/server/platform/housingFit/explanation/domain/entity/DiagnosisType.java
+++ b/src/main/java/com/pinHouse/server/platform/housingFit/explanation/domain/entity/DiagnosisType.java
@@ -1,6 +1,8 @@
 package com.pinHouse.server.platform.housingFit.explanation.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.pinHouse.server.core.response.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -16,5 +18,16 @@ public enum DiagnosisType {
     public String getDescription() {
         return description;
     }
+
+    @JsonCreator
+    public static DiagnosisType fromDescription(String description) {
+        for (DiagnosisType diagnosisType : DiagnosisType.values()) {
+            if (diagnosisType.getDescription().equals(description)) {
+                return diagnosisType;
+            }
+        }
+        throw new IllegalArgumentException(ErrorCode.INVALID_INPUT_ENUM.getMessage());
+    }
+
 }
 

--- a/src/main/java/com/pinHouse/server/platform/user/application/dto/request/UserRequest.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/dto/request/UserRequest.java
@@ -1,0 +1,13 @@
+package com.pinHouse.server.platform.user.application.dto.request;
+
+import com.pinHouse.server.platform.housing.facility.application.dto.request.FacilityType;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class UserRequest {
+
+    /// 목록 리스트
+    private List<FacilityType> facilityTypes;
+
+}

--- a/src/main/java/com/pinHouse/server/platform/user/application/dto/response/TempUserResponse.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/dto/response/TempUserResponse.java
@@ -1,0 +1,22 @@
+package com.pinHouse.server.platform.user.application.dto.response;
+
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
+import lombok.Builder;
+
+@Builder
+public record TempUserResponse(
+        String social,
+        String email,
+        String username
+) {
+
+    /// 정적 팩토리 메서드
+    public static TempUserResponse from(TempUserInfo tempUserInfo) {
+        return TempUserResponse.builder()
+                .social(tempUserInfo.getSocial())
+                .email(tempUserInfo.getEmail())
+                .username(tempUserInfo.getUsername())
+                .build();
+    }
+
+}

--- a/src/main/java/com/pinHouse/server/platform/user/application/service/UserService.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/service/UserService.java
@@ -1,5 +1,6 @@
 package com.pinHouse.server.platform.user.application.service;
 
+import com.pinHouse.server.platform.housing.facility.application.dto.request.FacilityType;
 import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
 import com.pinHouse.server.platform.user.application.dto.response.TempUserResponse;
 import com.pinHouse.server.platform.user.domain.entity.Gender;
@@ -12,8 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static com.pinHouse.server.core.util.BirthDayUtil.parseBirthday;
 
@@ -45,10 +45,8 @@ public class UserService implements UserUseCase {
 
         if (raw instanceof TempUserInfo info) {
 
-            /// 값 저장하기
-            saveUser(createUser(info));
-
-            /// 관심
+            /// 관심 목록과 함께, 값 저장하기
+            saveUser(createUser(info, request.getFacilityTypes()));
         }
     }
 
@@ -97,7 +95,7 @@ public class UserService implements UserUseCase {
     }
 
     /// 내부함수 유저 생성
-    private User createUser(TempUserInfo userInfo) {
+    private User createUser(TempUserInfo userInfo, List<FacilityType> facilityTypeList) {
 
         return User.of(
                 Provider.valueOf(userInfo.getSocial()),
@@ -107,7 +105,8 @@ public class UserService implements UserUseCase {
                 userInfo.getImageUrl(),
                 null,
                 parseBirthday(userInfo.getBirthyear(), userInfo.getBirthday()),
-                Gender.getGender(userInfo.getGender())
+                Gender.getGender(userInfo.getGender()),
+                facilityTypeList
         );
     }
 

--- a/src/main/java/com/pinHouse/server/platform/user/application/service/UserService.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/service/UserService.java
@@ -1,26 +1,46 @@
 package com.pinHouse.server.platform.user.application.service;
 
+import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
 import com.pinHouse.server.platform.user.domain.entity.User;
 import com.pinHouse.server.platform.user.domain.repository.UserJpaRepository;
 import com.pinHouse.server.platform.user.application.usecase.UserUseCase;
 import com.pinHouse.server.platform.user.domain.entity.Provider;
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
 import java.util.Optional;
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserService implements UserUseCase {
 
     private final UserJpaRepository repository;
 
+    /// 레디스
+    private final RedisTemplate<String, Object> redisTemplate;
+
     @Override
     public User saveUser(User user) {
         return repository.save(user);
     }
 
+    /**
+     * 온보딩을 통한 유저 회원가입
+     * @param request   회원가입
+     */
+    @Override
+    public void saveUser(UserRequest request) {
+
+    }
+
+    /**
+     * 이메일이 존재하는지 체크
+     * @param userId    유저ID
+     */
     @Override
     public boolean checkExistingById(UUID userId) {
         return repository.existsById(userId);
@@ -41,4 +61,34 @@ public class UserService implements UserUseCase {
     public Optional<User> loadUserBySocialAndSocialId(Provider social, String socialId) {
         return repository.findByProviderAndSocialId(social, socialId);
     }
+
+
+    /// 최초 회원가입에서 사용하는 함수
+    @Override
+    public TempUserInfo getUserByKey(String tempUserKey) {
+
+        /// 값 가져오기
+        Object raw = redisTemplate.opsForValue().get(tempUserKey);
+
+        /// 없다면 예외 처리
+        if (raw == null){
+            throw new IllegalStateException("TempUserInfo 복원 실패");
+        }
+
+        try {
+            if (raw instanceof TempUserInfo info) {
+                /// 레디스에서 삭제
+                redisTemplate.delete(tempUserKey);
+                /// 리턴
+                return info;
+            }
+
+            throw new IllegalStateException("지원하지 않는 Redis 값 타입: " + raw.getClass());
+        } catch (Exception e) {
+            throw new IllegalStateException("TempUserInfo 복원 실패", e);
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/pinHouse/server/platform/user/application/usecase/UserUseCase.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/usecase/UserUseCase.java
@@ -1,7 +1,9 @@
 package com.pinHouse.server.platform.user.application.usecase;
 
+import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
 import com.pinHouse.server.platform.user.domain.entity.Provider;
 import com.pinHouse.server.platform.user.domain.entity.User;
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -14,7 +16,13 @@ public interface UserUseCase {
 
     User saveUser(User user);
 
+    void saveUser(UserRequest request);
+
     boolean existsByEmail(String email);
 
     boolean checkExistingById(UUID userId);
+
+    /// 레디스에서 정보 가져오기
+    TempUserInfo getUserByKey(String key);
+
 }

--- a/src/main/java/com/pinHouse/server/platform/user/application/usecase/UserUseCase.java
+++ b/src/main/java/com/pinHouse/server/platform/user/application/usecase/UserUseCase.java
@@ -1,9 +1,9 @@
 package com.pinHouse.server.platform.user.application.usecase;
 
 import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
+import com.pinHouse.server.platform.user.application.dto.response.TempUserResponse;
 import com.pinHouse.server.platform.user.domain.entity.Provider;
 import com.pinHouse.server.platform.user.domain.entity.User;
-import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -14,15 +14,16 @@ public interface UserUseCase {
 
     Optional<User> loadUserBySocialAndSocialId(Provider socialType, String socialId);
 
-    User saveUser(User user);
+    /// 레디스에서 정보 가져오기
+    TempUserResponse getUserByKey(String tempUserKey);
 
-    void saveUser(UserRequest request);
-
-    boolean existsByEmail(String email);
+    void saveUser(String tempUserKey, UserRequest request);
 
     boolean checkExistingById(UUID userId);
 
-    /// 레디스에서 정보 가져오기
-    TempUserInfo getUserByKey(String key);
+    /// 외부용 함수
+
+    /// 개발용 유저 저장하기
+    User saveUser(User user);
 
 }

--- a/src/main/java/com/pinHouse/server/platform/user/domain/entity/Gender.java
+++ b/src/main/java/com/pinHouse/server/platform/user/domain/entity/Gender.java
@@ -10,7 +10,10 @@ public enum Gender {
     Male("M"),
 
     @JsonProperty("여성")
-    Female("F");
+    Female("F"),
+
+    @JsonProperty("미정")
+    Other("O");
 
     private final String value;
 

--- a/src/main/java/com/pinHouse/server/platform/user/domain/entity/User.java
+++ b/src/main/java/com/pinHouse/server/platform/user/domain/entity/User.java
@@ -2,12 +2,13 @@ package com.pinHouse.server.platform.user.domain.entity;
 
 import com.pinHouse.server.core.util.BirthDayUtil;
 import com.pinHouse.server.platform.BaseTimeEntity;
+import com.pinHouse.server.platform.housing.facility.application.dto.request.FacilityType;
 import com.pinHouse.server.security.oauth2.domain.OAuth2UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.UUID;
+import java.util.*;
 
 @Entity
 @Getter
@@ -45,6 +46,16 @@ public class User extends BaseTimeEntity {
 
     private LocalDate birthday;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "user_facility_types",
+            joinColumns = @JoinColumn(name = "user_id")
+    )
+    @Column(name = "facility_type")
+    private List<FacilityType> facilityTypes;
+
+
     @PrePersist
     public void generateUUID() {
         if (this.id == null) {
@@ -71,7 +82,7 @@ public class User extends BaseTimeEntity {
     /// 정적 팩토리 메서드
     public static User of(
             Provider provider, String socialId, String name, String email,
-            String profileImage, String phoneNumber, LocalDate birthday, Gender gender
+            String profileImage, String phoneNumber, LocalDate birthday, Gender gender, List<FacilityType> facilityTypes
     ) {
         return User.builder()
                 .id(UUID.randomUUID())
@@ -84,6 +95,7 @@ public class User extends BaseTimeEntity {
                 .birthday(birthday)
                 .gender(gender)
                 .role(Role.USER)
+                .facilityTypes(facilityTypes)
                 .build();
     }
 

--- a/src/main/java/com/pinHouse/server/platform/user/presentation/AuthApi.java
+++ b/src/main/java/com/pinHouse/server/platform/user/presentation/AuthApi.java
@@ -1,0 +1,96 @@
+package com.pinHouse.server.platform.user.presentation;
+
+import com.pinHouse.server.core.response.response.ApiResponse;
+import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
+import com.pinHouse.server.platform.user.application.dto.response.TempUserResponse;
+import com.pinHouse.server.platform.user.application.usecase.UserUseCase;
+import com.pinHouse.server.platform.user.presentation.swagger.AuthApiSpec;
+import com.pinHouse.server.security.jwt.service.JwtTokenUseCase;
+import com.pinHouse.server.security.oauth2.domain.PrincipalDetails;
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthApi implements AuthApiSpec {
+
+    private final UserUseCase service;
+    private final JwtTokenUseCase tokenService;
+
+    /**
+     * 임시 유저 정보 조회
+     * @param tempKey   조회할 키 캆
+     */
+    @GetMapping()
+    public ApiResponse<TempUserResponse> getUser(@RequestParam String tempKey) {
+
+        /// 서빗 실행 후, 리턴
+        return ApiResponse.ok(service.getUserByKey(tempKey));
+    }
+
+    /**
+     * 회원가입
+     * @param request 온보딩 데이터
+     */
+    @PostMapping()
+    public ApiResponse<Void> signUp(@RequestParam String tempKey,
+                                    @RequestBody @Valid UserRequest request) {
+
+        /// 서비스
+        service.saveUser(tempKey, request);
+
+        return ApiResponse.created();
+    }
+
+    /**
+     * 유저가 저장한, 핀포인트 저장하기
+     * @param principalDetails  유저
+     */
+    @PatchMapping()
+    public ApiResponse<Void> savePinPoint(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        /// 서비스
+
+        return ApiResponse.created();
+    }
+
+
+    /**
+     * 로그아웃
+     * @param request  HTTP 요청
+     * @param response HTTP 응답
+     */
+    @DeleteMapping()
+    public ApiResponse<Void> logout(@AuthenticationPrincipal PrincipalDetails principalDetails, HttpServletRequest request, HttpServletResponse response) {
+
+        /// 서비스 실행
+        tokenService.logout(principalDetails.getId(), request, response);
+
+        /// 응답
+        return ApiResponse.deleted();
+    }
+
+    /**
+     * 리프레쉬 토큰 재발급
+     * @param request   HTTP 요청
+     * @param response  HTTP 응답
+     */
+    @PutMapping()
+    public ApiResponse<Void> refresh(HttpServletRequest request, HttpServletResponse response) {
+
+        /// 서비스 실행
+        tokenService.reissueByRefreshToken(request, response);
+
+        /// 응답
+        return ApiResponse.updated();
+    }
+
+
+}
+

--- a/src/main/java/com/pinHouse/server/platform/user/presentation/DevAuthApi.java
+++ b/src/main/java/com/pinHouse/server/platform/user/presentation/DevAuthApi.java
@@ -35,7 +35,7 @@ public class DevAuthApi implements DevAuthApiSpec {
 
 
 
-    @PostMapping("/dev-login")
+    @PostMapping("/dev")
     public ApiResponse<Void> devLogin(HttpServletResponse httpServletResponse) {
 
         /// 테스트용 유저 정보 수정

--- a/src/main/java/com/pinHouse/server/platform/user/presentation/swagger/AuthApiSpec.java
+++ b/src/main/java/com/pinHouse/server/platform/user/presentation/swagger/AuthApiSpec.java
@@ -1,0 +1,54 @@
+package com.pinHouse.server.platform.user.presentation.swagger;
+
+import com.pinHouse.server.core.response.response.ApiResponse;
+import com.pinHouse.server.platform.user.application.dto.request.UserRequest;
+import com.pinHouse.server.security.oauth2.domain.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "인증 API", description = "회원가입, 로그아웃, 토큰 재발급에 관한 API 입니다.")
+public interface AuthApiSpec {
+
+    /**
+     * 회원가입 API
+     *
+     * @param request 회원가입 요청 데이터
+     */
+    @Operation(
+            summary = "회원가입 API",
+            description = "온보딩의 데이터를 바탕으로 회원가입합니다."
+    )
+    ApiResponse<Void> signUp(@RequestParam String tempKey, @RequestBody @Valid UserRequest request);
+
+
+    /**
+     * 로그아웃 API
+     *
+     * @param request  HTTP 요청
+     * @param response HTTP 응답
+     */
+    @Operation(
+            summary = "로그아웃 API",
+            description = "리프레쉬 토큰을 쿠키 및 DB 에서 삭제합니다."
+    )
+    ApiResponse<Void> logout(@AuthenticationPrincipal PrincipalDetails principalDetails, HttpServletRequest request, HttpServletResponse response);
+
+
+    /**
+     * 토큰 재발급 API
+     * @param request   HTTP 요청
+     * @param response  HTTP 응답
+     */
+    @Operation(
+            summary = "토큰 재발급 API",
+            description = "액세스 토큰을 바탕으로"
+    )
+    ApiResponse<Void> refresh(HttpServletRequest request, HttpServletResponse response);
+
+}

--- a/src/main/java/com/pinHouse/server/security/config/SecurityConfig.java
+++ b/src/main/java/com/pinHouse/server/security/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.pinHouse.server.security.config;
 import com.pinHouse.server.security.jwt.filter.JwtAuthenticationDeniedHandler;
 import com.pinHouse.server.security.jwt.filter.JwtAuthenticationFailureHandler;
 import com.pinHouse.server.security.jwt.filter.JwtAuthenticationFilter;
+import com.pinHouse.server.security.oauth2.handler.OAuth2FailureHandler;
 import com.pinHouse.server.security.oauth2.handler.OAuth2SuccessHandler;
 import com.pinHouse.server.security.oauth2.service.OAuth2UserService;
 import lombok.RequiredArgsConstructor;
@@ -28,11 +29,18 @@ import static com.pinHouse.server.platform.user.domain.entity.Role.USER;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    /// OAUTH2 관련
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
+    /// JWT 관련
     private final JwtAuthenticationFilter jwtFilter;
     private final JwtAuthenticationFailureHandler jwtFailureHandler;
     private final JwtAuthenticationDeniedHandler jwtDeniedHandler;
+
+    /// 시큐리티 및 CORS
     private final RequestMatcherHolder requestMatcherHolder;
     private final CorsConfigurationSource corsConfigurationSource;
 
@@ -57,9 +65,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                         .successHandler(oAuth2SuccessHandler)
-                        .failureHandler((request, response, exception) -> {
-                            response.sendRedirect("/login?error");
-                        })
+                        .failureHandler(oAuth2FailureHandler)
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception -> {

--- a/src/main/java/com/pinHouse/server/security/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/pinHouse/server/security/jwt/service/JwtTokenService.java
@@ -89,6 +89,9 @@ public class JwtTokenService implements JwtTokenUseCase {
 
     }
 
+    /**
+     * 로그아웃
+     */
     @Override
     public void logout(UUID userId, HttpServletRequest request, HttpServletResponse response) {
 

--- a/src/main/java/com/pinHouse/server/security/oauth2/domain/TempUserInfo.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/domain/TempUserInfo.java
@@ -16,7 +16,9 @@ public class TempUserInfo {
     private String email;
     private String username;
     private String gender;
+    private String birthyear;
     private String birthday;
+    private String imageUrl;
 
     /// 온보딩을 위한 정보를 포함하는 도메인
     public static TempUserInfo from (OAuth2UserInfo userInfo) {
@@ -26,7 +28,9 @@ public class TempUserInfo {
                 .email(userInfo.getEmail())
                 .username(userInfo.getUserName())
                 .gender(userInfo.getGender() == null ? Gender.Other.name() : userInfo.getGender())
-                .birthday(userInfo.getBirthYear() + userInfo.getBirthday())
+                .birthyear(userInfo.getBirthYear())
+                .birthday(userInfo.getBirthday())
+                .imageUrl(userInfo.getImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/pinHouse/server/security/oauth2/domain/TempUserInfo.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/domain/TempUserInfo.java
@@ -1,0 +1,33 @@
+package com.pinHouse.server.security.oauth2.domain;
+
+import com.pinHouse.server.platform.user.domain.entity.Gender;
+import lombok.*;
+
+/**
+ * 회원가입을 위한 리다이렉트
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TempUserInfo {
+    private String socialId;
+    private String social;
+    private String email;
+    private String username;
+    private String gender;
+    private String birthday;
+
+    /// 온보딩을 위한 정보를 포함하는 도메인
+    public static TempUserInfo from (OAuth2UserInfo userInfo) {
+        return TempUserInfo.builder()
+                .social(userInfo.getProvider())
+                .socialId(userInfo.getProviderId())
+                .email(userInfo.getEmail())
+                .username(userInfo.getUserName())
+                .gender(userInfo.getGender() == null ? Gender.Other.name() : userInfo.getGender())
+                .birthday(userInfo.getBirthYear() + userInfo.getBirthday())
+                .build();
+    }
+
+}

--- a/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2FailureHandler.java
@@ -1,0 +1,57 @@
+package com.pinHouse.server.security.oauth2.handler;
+
+import com.pinHouse.server.core.util.RedisKeyUtil;
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    /// 레디스 의존성 도입
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyUtil redisKeyUtil;
+
+    @Value("${cors.front.local}")
+    public String REDIRECT_PATH;
+
+    /**
+     * 실패 핸들러 예외 처리
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        /// SignupRequiredException 예외처리 받았으면 실행
+        if (exception instanceof SignupRequiredException) {
+
+            /// 레디스로 회원가입 키 생성
+            String tempUserKey = redisKeyUtil.generateOAuth2TempUserKey();
+
+            /// 임시 유저 처리
+            TempUserInfo userInfo = ((SignupRequiredException) exception).getUserInfo();
+
+            /// 레디스에 값 추가( 유효시간 5분 )
+            redisTemplate.opsForValue().set(tempUserKey, userInfo, Duration.ofMinutes(5));
+
+            String extraInfoUrl = REDIRECT_PATH + "/extra?tempKey=" + tempUserKey;
+
+            /// 응답을 리다이렉트
+            response.sendRedirect(extraInfoUrl);
+        } else {
+            response.sendRedirect("/login?error");
+        }
+    }
+}

--- a/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -20,7 +20,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtTokenUseCase tokenService;
 
-    @Value("${cors.front.dev}")
+    @Value("${cors.front.local}")
     public String REDIRECT_PATH;
 
     /*
@@ -32,16 +32,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
         /// AccessToken과 Refresh 토큰 생성
-
         tokenService.createAccessToken(response, authentication);
         tokenService.createRefreshToken(response, authentication);
 
         /// 시큐리티 홀더에 해당 멤버 저장
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        log.info("시큐리티에 저장된 인증 정보 :{}", authentication.getPrincipal().toString());
-
-        // 쿠키와 함께 리다이렉트 (프론트 홈 주소)
+        /// 쿠키와 함께 리다이렉트 (프론트 홈 주소)
         getRedirectStrategy().sendRedirect(request, response, REDIRECT_PATH);
     }
 }

--- a/src/main/java/com/pinHouse/server/security/oauth2/handler/SignupRequiredException.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/handler/SignupRequiredException.java
@@ -1,0 +1,17 @@
+package com.pinHouse.server.security.oauth2.handler;
+
+import com.pinHouse.server.security.oauth2.domain.TempUserInfo;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class SignupRequiredException extends AuthenticationException {
+
+    private final TempUserInfo userInfo;
+
+    public SignupRequiredException(TempUserInfo userInfo) {
+        super("SIGNUP_REQUIRED");
+        this.userInfo = userInfo;
+    }
+
+}


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 신규 가입 시 OAuth2 인증 후 회원가입 화면으로 리다이렉트 되도록 기능 구현
- Redis 설정 추가 및 TempUserInfo 저장 로직 구현
- OAuth2FailureHandler 추가하여 회원가입 필요 예외 시 프론트엔드로 리다이렉트 처리
- UserService에 Redis 기반 임시 유저 조회/삭제 기능 추가
- SecurityConfig 에 OAuth2FailureHandler 적용
- 유저 회원가입 기능 구현 (UserRequest 기반 저장)
- 선호 인프라와 함께 유저 회원가입 구현 추가

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- TempUserInfo 는 임시로 Redis 에 저장되며 5분 후 만료됩니다.
- 프론트엔드는 리다이렉트 시 전달되는 tempKey 를 활용해 회원가입 절차를 이어가야 합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
- localhost:3000으로 리다이렉트가 되는 사진입니다.
<img width="1123" height="618" alt="스크린샷 2025-09-28 21 24 00" src="https://github.com/user-attachments/assets/8ed404fe-87c7-4c80-86e0-d58e2905ed9e" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
