### PR TITLE
🔥 hotfix: 로그인 리다이렉트 실패 문제

### DIFF
--- a/src/main/java/com/pinHouse/server/security/config/CorsConfig.java
+++ b/src/main/java/com/pinHouse/server/security/config/CorsConfig.java
@@ -16,6 +16,9 @@ public class CorsConfig {
     @Value("${cors.front.dev}")
     private String front_dev;
 
+    @Value("${cors.front.prod}")
+    private String front_prod;
+
     @Value("${cors.back.dev}")
     private String back_dev;
 
@@ -29,6 +32,7 @@ public class CorsConfig {
         /// CORS 추가
         configuration.addAllowedOriginPattern(front_local);
         configuration.addAllowedOriginPattern(front_dev);
+        configuration.addAllowedOriginPattern(front_prod);
         configuration.addAllowedOriginPattern(back_dev);
 
         configuration.addAllowedHeader("*");

--- a/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2FailureHandler.java
@@ -25,7 +25,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
     private final RedisTemplate<String, Object> redisTemplate;
     private final KeyUtil keyUtil;
 
-    @Value("${cors.front.local}")
+    @Value("${cors.front.redirect}")
     public String REDIRECT_PATH;
 
     /**

--- a/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pinHouse/server/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -26,7 +26,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtProvider jwtProvider;
     private final HttpUtil httpUtil;
 
-    @Value("${cors.front.local}")
+    @Value("${cors.front.redirect}")
     private String REDIRECT_PATH;
 
     /*


### PR DESCRIPTION
## 📌 작업한 내용
리다이렉트 주소를 실제 서비스 도메인으로 이동하도록 수정해 잘못된 경로 요청 시 올바른 페이지로 안내되도록 했습니다. CORS 설정을 추가해 프론트엔드 도메인에서의 API 호출이 정상적으로 동작하도록 허용했습니다.

## 🔍 참고 사항
- 리다이렉트: 기존 경로나 임시 주소 대신 배포된 서비스 도메인 기준으로 이동 처리.
- CORS: 프론트엔드 Origin을 허용 목록에 추가하고, 필요한 메서드/헤더를 열어 개발·운영 환경 모두에서 호출 가능하도록 구성.

## 🖼️ 스크린샷
UI 변경 사항 없음

## 🔗 관련 이슈
서비스 배포 및 프론트엔드 연동 관련 이슈

## ✅ 체크리스트
- [x] 로컬 및 서버 환경에서 리다이렉트 동작 확인
- [x] 허용 Origin에서 CORS 에러 미발생 확인
- [x] 문서화 필요 여부 확인