### PR TITLE
fix: release 브랜치 배포 임시 차단

### DIFF
--- a/.github/workflows/pinhouse-nonprod-ci.yml
+++ b/.github/workflows/pinhouse-nonprod-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/**
 
 permissions:
   contents: read


### PR DESCRIPTION
## 📌 작업한 내용
- release 브랜치의 자동 배포 워크플로우를 임시로 비활성화.
- CI/CD 파이프라인에서 release 브랜치 배포 단계 스킵하도록 수정.

## 🔍 참고 사항
- v1.0.1 릴리스 전 추가 검증 필요로 인한 긴급 조치.
- dev → release/v1.0.1 PR 병합 후 수동 검증 완료 시 복구 예정.
- 배포 사고 방지를 위한 안전장치로 프로덕션 배포 차단.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#97

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인