### PR TITLE
release: CI/CD 개선사항 및 버그 파이프라인 수정

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# .github/release.yml (GitHub 공식 API 규격)
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: '🚀 새로운 기능 (Features)'
+      labels:
+        - 'feat'
+        - 'feature'
+    - title: '✨ 기능 개선 (Improvements)'
+      labels:
+        - 'enhancement'
+        - 'refactor'
+    - title: '🐛 버그 수정 (Bug Fixes)'
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+    - title: '🛠️ 인프라 및 유지보수'
+      labels:
+        - 'infra'
+        - 'chore'

--- a/.github/workflows/pinhouse-bug-issue.yml
+++ b/.github/workflows/pinhouse-bug-issue.yml
@@ -1,0 +1,78 @@
+name: PinHouse-BE 버그 알림 파이프라인
+
+# 다시 열린 이슈도 포함
+on:
+  issues:
+    types: [ opened, reopened ]
+
+# 환경 변수 설정
+env:
+  USER_MAP_JSON: ${{ secrets.USER_MAP_JSON }}
+  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+  DISCORD_ROLE: ${{ secrets.DISCORD_ROLE }}
+  DISCORD_AVATAR_URL: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+
+# Job
+jobs:
+  notify-bug-issue:
+    runs-on: ubuntu-22.04
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    environment: PinHouse_bug
+    steps:
+      - name: 데이터 준비
+        id: prep
+        run: |
+          # 1. 멘션 처리 함수 (사용자 매핑 로직 강화)
+          get_mention() {
+            local login=$1
+            local mapped=$(echo "$USER_MAP_JSON" | jq -r --arg id "$login" '.[$id] // empty')
+            if [ -n "$mapped" ]; then echo "$mapped"; else echo "@$login"; fi
+          }
+
+          # 2. 작성자 및 담당자 멘션 생성
+          AUTHOR=$(get_mention "${{ github.event.issue.user.login }}")
+          echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+
+          ASSIGNEES=$(echo '${{ toJson(github.event.issue.assignees) }}' | jq -r --argjson map "$USER_MAP_JSON" '
+            [.[].login | ($map[.] // "@" + .)] | join(", ")
+          ')
+          echo "assignees=${ASSIGNEES:-'미지정 👤'}" >> $GITHUB_OUTPUT
+
+          # 3. 라벨을 예쁘게 포맷팅 (예: `bug`, `p0`)
+          LABELS=$(echo '${{ toJson(github.event.issue.labels.*.name) }}' | jq -r 'map("`" + . + "`") | join(", ")')
+          echo "labels=$LABELS" >> $GITHUB_OUTPUT
+
+      - name: Discord 알림 전송
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ env.DISCORD_WEBHOOK_URL }}
+          status: 'failure'
+
+          title: '🚨 BUG REPORT: ${{ github.event.issue.title }}'
+          url: ${{ github.event.issue.html_url }}
+
+          # 2. 역할 멘션은 content에 그대로 두어 최상단에 노출되게 합니다.
+          content: '${{ env.DISCORD_ROLE }} 버그가 접수되었습니다. 확인 부탁드립니다!'
+
+          description: |
+            **레포지토리**
+            ${{ github.event.repository.full_name }} (FE)
+
+            **작성자**
+            ${{ steps.prep.outputs.author }}
+
+            **담당자**
+            ${{ steps.prep.outputs.assignees }}
+
+            **라벨**
+            ${{ steps.prep.outputs.labels }}
+
+            **📝 내용**
+            ```text
+            ${{ github.event.issue.body }}
+            ```
+
+          # 4. 기타 스타일 옵션
+          color: 0xff4d4d
+          username: GitHub BE Bug Bot
+          avatar_url: ${{ env.DISCORD_AVATAR_URL }}

--- a/.github/workflows/pinhouse-nonprod-ci.yml
+++ b/.github/workflows/pinhouse-nonprod-ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           status: ${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
           webhook: ${{ env.DISCORD_WEBHOOK_URL }}
-          title: "배포(CI) 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          title: "PinHouse ${{ github.event.pull_request.base.ref }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
           description: |
             **브랜치**: `${{ env.BRANCH_NAME }}`
             **환경**: ${{ env.ENV_TYPE }}

--- a/.github/workflows/pinhouse-nonprod-ci.yml
+++ b/.github/workflows/pinhouse-nonprod-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/**
 
 permissions:
   contents: read

--- a/.github/workflows/pinhouse-pr.yml
+++ b/.github/workflows/pinhouse-pr.yml
@@ -164,7 +164,7 @@ jobs:
         with:
           status: ${{ (needs.main-branch-guard.result == 'success' && needs.lint.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
           webhook: ${{ github.event.pull_request.base.ref == 'main' && env.DISCORD_WEBHOOK_PROD_URL || env.DISCORD_WEBHOOK_PR_URL }}
-          title: "${{ github.event.pull_request.base.ref }} PR 결과 [${{ (needs.main-branch-guard.result == 'success' && needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          title: "PinHouse ${{ github.event.pull_request.base.ref }} PR 결과 [${{ (needs.main-branch-guard.result == 'success' && needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
           description: |
             **PR 제목**: ${{ github.event.pull_request.title }}
             **작성자**: ${{ steps.prep.outputs.author }}

--- a/.github/workflows/pinhouse-prod-ci.yml
+++ b/.github/workflows/pinhouse-prod-ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           status: ${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
           webhook: ${{ env.DISCORD_WEBHOOK_URL }}
-          title: "배포(CI) 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          title: "PinHouse ${{ github.event.pull_request.base.ref }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
           description: |
             **브랜치**: `${{ env.BRANCH_NAME }}`
             **환경**: ${{ env.ENV_TYPE }}


### PR DESCRIPTION
## 📌 작업한 내용
- **PR #106 병합**: release 브랜치 배포 임시 차단 적용
- **PR #107 병합**: Discord 알림 포맷 개선 + 릴리즈 워크플로우 추가  
- **PR #109 병합**: 버그 이슈 자동화 파이프라인 구현 (`.github/workflows/bug-report.yml`)

## 🔍 참고 사항
- **배포 안전장치**: v1.0.1 릴리스 전 release 자동 배포 차단
- **알림 개선**: 빌드 시간, PR 번호, 커밋 해시 포함 Discord 메시지
- **버그 파이프라인**: `issue_category: bug` 시 자동 템플릿 + 환경정보 수집
- 전체 CI/CD 워크플로우 안정화 및 이슈 관리 자동화 완료

## 🖼️ 스크린샷

## 🔗 관련 이슈
#97 (CI/CD 파이프라인 개선)  
#108 (버그 워크플로우 작성)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인