### PR TITLE
hotfix: Discord 알림 메시지 포맷 수정 (#112)

### DIFF
--- a/.github/workflows/pinhouse-nonprod-ci.yml
+++ b/.github/workflows/pinhouse-nonprod-ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           status: ${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
           webhook: ${{ env.DISCORD_WEBHOOK_URL }}
-          title: "PinHouse ${{ github.event.pull_request.base.ref }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          title: "PinHouse ${{ env.BRANCH_NAME }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
           description: |
             **브랜치**: `${{ env.BRANCH_NAME }}`
             **환경**: ${{ env.ENV_TYPE }}

--- a/.github/workflows/pinhouse-prod-ci.yml
+++ b/.github/workflows/pinhouse-prod-ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           status: ${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
           webhook: ${{ env.DISCORD_WEBHOOK_URL }}
-          title: "PinHouse ${{ github.event.pull_request.base.ref }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          title: "PinHouse ${{ env.BRANCH_NAME }} CI 결과 [${{ (needs.lint.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
           description: |
             **브랜치**: `${{ env.BRANCH_NAME }}`
             **환경**: ${{ env.ENV_TYPE }}


### PR DESCRIPTION
## 📌 작업한 내용
- CI/CD 파이프라인 내 Discord 알림 메시지 포맷 수정

## 🔍 참고 사항
- 메시지 내 `${{ github.head_ref }}` 등 GitHub 컨텍스트 변수 이스케이프

## 🖼️ 스크린샷

## 🔗 관련 이슈
#112 (CICD 파이프라인 알림 문제)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] Discord Webhook 테스트 성공
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 파이프라인의 Discord 알림 제목 표시 방식을 업데이트했습니다. 알림이 현재 브랜치 이름을 올바르게 반영하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->