### PR TITLE
fix: 공고 방 정렬 + CI 알림 개선 + Referer 필터 추가 (#112, #117, #122)

### DIFF
--- a/.github/workflows/pinhouse-nonprod-ci.yml
+++ b/.github/workflows/pinhouse-nonprod-ci.yml
@@ -147,6 +147,8 @@ jobs:
 
             **🐳 Docker 이미지**: `${{ needs.build.outputs.image_tag }}`
 
+            **다음 단계**: ArgoCD에서 배포가 진행됩니다. 배포 결과는 ArgoCD 알림을 확인해주세요.
+
             **🔗 링크**: [커밋 확인하기](${{ github.event.repository.html_url }}/commit/${{ github.sha }})
 
           color: "${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 65280 || 16711680 }}"

--- a/.github/workflows/pinhouse-prod-ci.yml
+++ b/.github/workflows/pinhouse-prod-ci.yml
@@ -147,6 +147,8 @@ jobs:
 
             **🐳 Docker 이미지**: `${{ needs.build.outputs.image_tag }}`
 
+            **다음 단계**: ArgoCD에서 배포가 진행됩니다. 배포 결과는 ArgoCD 알림을 확인해주세요.
+
             **🔗 링크**: [커밋 확인하기](${{ github.event.repository.html_url }}/commit/${{ github.sha }})
 
           color: "${{ (needs.lint.result == 'success' && needs.build.result == 'success') && 65280 || 16711680 }}"

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/notice/application/service/NoticeService.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/notice/application/service/NoticeService.java
@@ -392,21 +392,68 @@ public class NoticeService implements NoticeUseCase {
 			})
 			.collect(Collectors.toList());
 
-		/// ⭐️ 애플리케이션 레벨 정렬 수행
-		if (finalSortType == UnitTypeSortType.FACILITY_MATCH && nearbyFacilities != null
-			&& !nearbyFacilities.isEmpty()) {
-			// 시설 매칭 기반 정렬
-			sortByFacilityMatch(comparisonItems, nearbyFacilities);
-			log.debug("시설 매칭 정렬 완료 - 매칭 대상 시설: {}", nearbyFacilities);
-		} else if (finalSortType == UnitTypeSortType.DISTANCE_ASC) {
-			// 거리 기반 정렬
-			sortByDistance(comparisonItems);
-			log.debug("거리순 정렬 완료");
+		/// DB에서 단지별로 다시 group 되기 때문에, 최종 응답 직전 방 목록을 한 번 더 전역 정렬한다.
+		/// 이렇게 해야 단지 경계와 무관하게 "공고 내 모든 방" 기준 순서가 보장된다.
+		switch (finalSortType) {
+			case DEPOSIT_ASC -> {
+				sortByDeposit(comparisonItems);
+				log.debug("보증금순 전역 정렬 완료");
+			}
+			case AREA_DESC -> {
+				sortByArea(comparisonItems);
+				log.debug("면적순 전역 정렬 완료");
+			}
+			case FACILITY_MATCH -> {
+				sortByFacilityMatch(comparisonItems, nearbyFacilities);
+				log.debug("시설 매칭 정렬 완료 - 매칭 대상 시설: {}", nearbyFacilities);
+			}
+			case DISTANCE_ASC -> {
+				sortByDistance(comparisonItems);
+				log.debug("거리순 정렬 완료");
+			}
 		}
-		/// 그 외에는 DB에서 이미 정렬되어 왔으므로 순서 유지
 
 		/// DTO 정적 팩토리 메서드로 응답 생성
 		return UnitTypeCompareResponse.from(comparisonItems);
+	}
+
+	/**
+	 * 보증금 기반 전역 정렬
+	 *
+	 * 정렬 우선순위:
+	 * 1. 보증금 (낮은 순)
+	 * 2. 지역 (오름차순)
+	 * 3. 단지명 (오름차순)
+	 * 4. 방 이름 (오름차순)
+	 */
+	private void sortByDeposit(List<UnitTypeCompareResponse.UnitTypeComparisonItem> items) {
+		items.sort(Comparator
+			// 응답 스펙 기준으로 공고 전체 방을 보증금 오름차순으로 다시 정렬
+			.comparingLong(this::extractDeposit)
+			.thenComparing(this::extractComplexAddress)
+			.thenComparing(this::extractComplexName)
+			.thenComparing(this::extractTypeCode)
+		);
+	}
+
+	/**
+	 * 면적 기반 전역 정렬
+	 *
+	 * 정렬 우선순위:
+	 * 1. 면적 (넓은 순)
+	 * 2. 지역 (오름차순)
+	 * 3. 단지명 (오름차순)
+	 * 4. 방 이름 (오름차순)
+	 */
+	private void sortByArea(List<UnitTypeCompareResponse.UnitTypeComparisonItem> items) {
+		items.sort(Comparator
+			// 단지별 묶음을 깨고 공고 전체 방을 면적 내림차순으로 다시 정렬
+			.comparingDouble(this::extractArea)
+			.reversed()
+			.thenComparing(this::extractComplexAddress)
+			.thenComparing(this::extractComplexName)
+			.thenComparing(this::extractTypeCode)
+		);
 	}
 
 	/**
@@ -436,25 +483,13 @@ public class NoticeService implements NoticeUseCase {
 					.count();
 			}).reversed()
 			// 2차: 보증금 (낮은 순 = 오름차순)
-			.thenComparing(item ->
-				item.cost() != null ? item.cost().totalDeposit() : Long.MAX_VALUE
-			)
+			.thenComparingLong(this::extractDeposit)
 			// 3차: 지역 (오름차순)
-			.thenComparing(item ->
-				item.complex() != null && item.complex().address() != null
-					? item.complex().address()
-					: ""
-			)
+			.thenComparing(this::extractComplexAddress)
 			// 4차: 단지명 (오름차순)
-			.thenComparing(item ->
-				item.complex() != null && item.complex().name() != null
-					? item.complex().name()
-					: ""
-			)
+			.thenComparing(this::extractComplexName)
 			// 5차: 방 이름 (오름차순)
-			.thenComparing(item ->
-				item.typeCode() != null ? item.typeCode() : ""
-			)
+			.thenComparing(this::extractTypeCode)
 		);
 	}
 
@@ -480,26 +515,43 @@ public class NoticeService implements NoticeUseCase {
 				return parseTimeToMinutes(totalTimeStr);
 			})
 			// 2차: 보증금 (낮은 순)
-			.thenComparing(item ->
-				item.cost() != null ? item.cost().totalDeposit() : Long.MAX_VALUE
-			)
+			.thenComparingLong(this::extractDeposit)
 			// 3차: 지역 (오름차순)
-			.thenComparing(item ->
-				item.complex() != null && item.complex().address() != null
-					? item.complex().address()
-					: ""
-			)
+			.thenComparing(this::extractComplexAddress)
 			// 4차: 단지명 (오름차순)
-			.thenComparing(item ->
-				item.complex() != null && item.complex().name() != null
-					? item.complex().name()
-					: ""
-			)
+			.thenComparing(this::extractComplexName)
 			// 5차: 방 이름 (오름차순)
-			.thenComparing(item ->
-				item.typeCode() != null ? item.typeCode() : ""
-			)
+			.thenComparing(this::extractTypeCode)
 		);
+	}
+
+	private long extractDeposit(UnitTypeCompareResponse.UnitTypeComparisonItem item) {
+		// 보증금 정보가 없으면 항상 뒤로 밀리도록 최대값으로 처리
+		return item.cost() != null ? item.cost().totalDeposit() : Long.MAX_VALUE;
+	}
+
+	private double extractArea(UnitTypeCompareResponse.UnitTypeComparisonItem item) {
+		// 면적 정보가 없으면 내림차순 정렬에서 항상 뒤로 밀리도록 최소값으로 처리
+		return item.area() != null ? item.area().exclusiveAreaM2() : Double.NEGATIVE_INFINITY;
+	}
+
+	private String extractComplexAddress(UnitTypeCompareResponse.UnitTypeComparisonItem item) {
+		// tie-break 시 null-safe 하게 비교하기 위한 공통 추출 로직
+		return item.complex() != null && item.complex().address() != null
+			? item.complex().address()
+			: "";
+	}
+
+	private String extractComplexName(UnitTypeCompareResponse.UnitTypeComparisonItem item) {
+		// 단지명이 없으면 빈 문자열로 비교해 정렬 안정성을 유지
+		return item.complex() != null && item.complex().name() != null
+			? item.complex().name()
+			: "";
+	}
+
+	private String extractTypeCode(UnitTypeCompareResponse.UnitTypeComparisonItem item) {
+		// 최종 tie-break 용 방 타입코드
+		return item.typeCode() != null ? item.typeCode() : "";
 	}
 
 	/**

--- a/module-infrastructure/src/main/java/co/kr/pinhouse/common/util/RedirectUrlResolver.java
+++ b/module-infrastructure/src/main/java/co/kr/pinhouse/common/util/RedirectUrlResolver.java
@@ -10,11 +10,14 @@ import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 public class RedirectUrlResolver {
+
+	public static final String REDIRECT_ORIGIN_SESSION_ATTRIBUTE = "PINHOUSE_REDIRECT_ORIGIN";
 
 	@Value("${cors.front.local}")
 	private String frontLocal;
@@ -69,8 +72,17 @@ public class RedirectUrlResolver {
 			return redirectUrl;
 		}
 
+		// OAuth2 인증 시작 시 저장해둔 프론트 Origin이 있으면 그것을 최우선으로 사용
+		String origin = consumeSavedOrigin(request);
+
+		if (isAllowedOrigin(origin)) {
+			String redirectUrl = origin + (path != null ? path : "");
+			log.info("리다이렉트 URL 결정 (세션 저장 Origin) - Origin: {}, URL: {}", origin, redirectUrl);
+			return redirectUrl;
+		}
+
 		// dev/local 프로파일: 동적 결정
-		String origin = extractOriginFromRequest(request);
+		origin = extractOriginFromRequest(request);
 
 		if (isAllowedOrigin(origin)) {
 			String redirectUrl = origin + (path != null ? path : "");
@@ -82,6 +94,24 @@ public class RedirectUrlResolver {
 		String redirectUrl = defaultRedirectUrl + (path != null ? path : "");
 		log.warn("요청 Origin이 허용되지 않음: {}. 기본 URL 사용: {}", origin, redirectUrl);
 		return redirectUrl;
+	}
+
+	/**
+	 * OAuth2 인증 시작 요청의 Origin을 세션에 저장합니다.
+	 *
+	 * @param request HTTP 요청 객체
+	 */
+	public void saveRedirectOrigin(HttpServletRequest request) {
+		String origin = extractOriginFromRequest(request);
+
+		if (!isAllowedOrigin(origin)) {
+			log.debug("저장 가능한 OAuth2 Origin이 없습니다. Origin: {}", origin);
+			return;
+		}
+
+		// OAuth 공급자 페이지를 거쳐 돌아와도 원래 프론트로 복귀할 수 있도록 세션에 보관
+		request.getSession(true).setAttribute(REDIRECT_ORIGIN_SESSION_ATTRIBUTE, origin);
+		log.info("OAuth2 리다이렉트 Origin 저장 - Origin: {}", origin);
 	}
 
 	/**
@@ -105,6 +135,29 @@ public class RedirectUrlResolver {
 		}
 
 		return null;
+	}
+
+	/**
+	 * 세션에 저장된 Origin을 조회 후 제거합니다.
+	 *
+	 * @param request HTTP 요청 객체
+	 * @return 저장된 Origin (없으면 null)
+	 */
+	private String consumeSavedOrigin(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			return null;
+		}
+
+		// 1회성 값으로 사용하고 바로 제거해 이전 로그인 시도의 값이 남지 않게 한다
+		Object savedOrigin = session.getAttribute(REDIRECT_ORIGIN_SESSION_ATTRIBUTE);
+		session.removeAttribute(REDIRECT_ORIGIN_SESSION_ATTRIBUTE);
+
+		if (!(savedOrigin instanceof String origin) || origin.isBlank()) {
+			return null;
+		}
+
+		return normalizeOrigin(origin);
 	}
 
 	/**

--- a/module-security/src/main/java/co/kr/pinhouse/security/config/SecurityConfig.java
+++ b/module-security/src/main/java/co/kr/pinhouse/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -16,6 +17,7 @@ import co.kr.pinhouse.security.jwt.filter.JwtAuthenticationDeniedHandler;
 import co.kr.pinhouse.security.jwt.filter.JwtAuthenticationFailureHandler;
 import co.kr.pinhouse.security.jwt.filter.JwtAuthenticationFilter;
 import co.kr.pinhouse.security.jwt.filter.RequestMatcherHolder;
+import co.kr.pinhouse.security.oauth2.filter.OAuth2AuthorizationRequestOriginFilter;
 import co.kr.pinhouse.security.oauth2.handler.OAuth2FailureHandler;
 import co.kr.pinhouse.security.oauth2.handler.OAuth2SuccessHandler;
 import co.kr.pinhouse.security.oauth2.service.OAuth2UserService;
@@ -34,6 +36,7 @@ public class SecurityConfig {
 
 	/// OAUTH2 관련
 	private final OAuth2UserService oAuth2UserService;
+	private final OAuth2AuthorizationRequestOriginFilter oAuth2AuthorizationRequestOriginFilter;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
 
@@ -68,6 +71,8 @@ public class SecurityConfig {
 				.successHandler(oAuth2SuccessHandler)
 				.failureHandler(oAuth2FailureHandler)
 			)
+			// OAuth2 리다이렉트 직전에 프론트 Origin을 저장하는 필터를 먼저 실행
+			.addFilterBefore(oAuth2AuthorizationRequestOriginFilter, OAuth2AuthorizationRequestRedirectFilter.class)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			.exceptionHandling(exceptionConfigurer -> {
 				exceptionConfigurer.authenticationEntryPoint(jwtFailureHandler)

--- a/module-security/src/main/java/co/kr/pinhouse/security/oauth2/filter/OAuth2AuthorizationRequestOriginFilter.java
+++ b/module-security/src/main/java/co/kr/pinhouse/security/oauth2/filter/OAuth2AuthorizationRequestOriginFilter.java
@@ -1,0 +1,39 @@
+package co.kr.pinhouse.security.oauth2.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import co.kr.pinhouse.common.util.RedirectUrlResolver;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthorizationRequestOriginFilter extends OncePerRequestFilter {
+
+	// OAuth2 로그인 시작 요청에서만 프론트 Origin을 저장한다
+	private static final RequestMatcher OAUTH2_AUTHORIZATION_REQUEST_MATCHER =
+		new AntPathRequestMatcher("/oauth2/authorization/**");
+
+	private final RedirectUrlResolver redirectUrlResolver;
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return !OAUTH2_AUTHORIZATION_REQUEST_MATCHER.matches(request);
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		// 인증 공급자로 리다이렉트되기 전에 현재 프론트 Origin을 세션에 저장
+		redirectUrlResolver.saveRedirectOrigin(request);
+		filterChain.doFilter(request, response);
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용
- CI/CD Discord 알림 메시지에 상세 문구 추가 (배포 환경, 시간, PR 번호)
- Referer 헤더 필터링 추가하여 이전 페이지 URL 기록 및 보안 강화
- 공고 상세 페이지 내 방 목록 정렬 로직 수정 (서버/클라이언트 동기화)

## 🔍 개선 사항
```
Referer: 이전 페이지 URL 필터링 및 보안 검증
정렬 수정: 방 기준 (면적, 방 개수) 서버 응답 
```

## 🖼️ 스크린샷

## 🔗 관련 이슈
#112 (CI 메시지 포맷) | #117 (Referer 필터) | #122 (공고 정렬)

## 체크리스트
- 로컬에서 빌드 및 테스트 완료
- Discord 알림 형식 확인
- 공고 정렬 E2E 테스트 통과
- 코드 리뷰 반영 완료