### PR TITLE
 fix: 대중교통 조회 색상 표시 문제 해결 (#119)

### DIFF
--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/ChipType.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/ChipType.java
@@ -5,7 +5,7 @@ public enum ChipType {
 	WALK("#BBBAC5"),
 	BUS("#BBBBBB"),
 	SUBWAY("#BBBBBB"),
-	TRAIN("BBBBBB"),
+	TRAIN("#BBBBBB"),
 	AIR("#2C7A7B"); // 항공용 컬러/아이콘은 디자인에 맞게 조정
 
 	public final String defaultBg;

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/DistanceResponse.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/DistanceResponse.java
@@ -15,6 +15,10 @@ import co.kr.pinhouse.domain.housing.complex.domain.transit.TrainType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+/**
+ * 공고/비교 서비스에서 아직 사용하는 구 교통 응답 DTO.
+ * 외부 API 응답용이라기보다 캐시된 RootResult에서 총 시간과 레거시 chip 정보를 재조립하는 용도에 가깝다.
+ */
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DistanceResponse(
@@ -32,7 +36,7 @@ public record DistanceResponse(
 	List<TransitResponse> routes
 ) {
 
-	/// 정적 팩토리 메서드
+	/// NoticeService 등 기존 호출부가 쓰는 경량 응답으로 변환
 	public static DistanceResponse from(RootResult rootResult, List<TransitResponse> routes) {
 		int minutes = rootResult.totalTime();
 		return DistanceResponse.builder()

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/TransitInfoResponse.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/dto/response/TransitInfoResponse.java
@@ -8,7 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 /**
- * 대중교통 경로 전체 정보 (총 시간/거리 + 구간별 정보)
+ * 임대주택 상세조회에서 사용하는 요약 교통 응답.
+ * 최적 1개 경로만 선택해 총 시간/거리와 색 막대용 segments를 내려준다.
  */
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/service/ComplexService.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/service/ComplexService.java
@@ -75,7 +75,7 @@ public class ComplexService implements ComplexUseCase {
 		/// 주변 인프라 조회
 		NoticeFacilityListResponse nearFacilities = facilityService.getNearFacilities(complex.getId());
 
-		/// 거리 계산 - TransitInfo 생성
+		/// 상세조회는 상위 1개 경로만 요약한 경량 응답을 사용한다.
 		TransitInfoResponse transitInfo = getTransitInfo(id, pinPointId);
 
 		/// 리턴
@@ -113,7 +113,7 @@ public class ComplexService implements ComplexUseCase {
 			.toList();
 	}
 
-	/// 대중교통 시뮬레이터 (새 스키마 - 3개 경로 한 번에)
+	/// 대중교통 전용 API는 상위 3개 경로와 step 정보를 모두 내려준다.
 	@Override
 	@Transactional
 	public TransitRoutesResponse getDistanceV2(String id, String pinPointId) throws UnsupportedEncodingException {
@@ -479,7 +479,7 @@ public class ComplexService implements ComplexUseCase {
 		PinPoint pinPoint = pinPointService.loadPinPoint(pinPointId);
 		Location pinPointLocation = pinPoint.getLocation();
 
-		/// 대중교통 경로 계산
+		/// 실제 경로 조회는 ODsay 응답을 PathResult로 표준화한 뒤 후속 매퍼에 위임한다.
 		PathResult pathResult = distanceUtil.findPathResult(
 			pinPointLocation.getLatitude(),
 			pinPointLocation.getLongitude(),
@@ -500,42 +500,34 @@ public class ComplexService implements ComplexUseCase {
 		}
 	}
 
-	/// TransitInfo 조회 (임대주택 상세조회용)
+	/// 임대주택 상세조회용 요약 교통 정보.
+	/// 색상 정보를 잃지 않도록 TransitInfoResponse 자체를 캐시한다.
 	@Transactional(readOnly = true, noRollbackFor = CustomException.class)
 	public TransitInfoResponse getTransitInfo(String id, String pinPointId) throws UnsupportedEncodingException {
 
-		/// Redis 캐시에서 RootResult 먼저 확인
-		co.kr.pinhouse.domain.housing.complex.domain.transit.RootResult cachedRootResult =
-			distanceCacheService.getRootResult(id, pinPointId);
+		/// 상세조회는 색상/segment 정보가 직렬화된 TransitInfo 캐시를 우선 사용한다.
+		TransitInfoResponse cachedTransitInfo = distanceCacheService.getTransitInfo(id, pinPointId);
 
-		if (cachedRootResult != null) {
-			log.debug("Using cached RootResult for TransitInfo - complexId={}, pinPointId={}", id, pinPointId);
-			return mapper.toTransitInfoResponse(cachedRootResult);
+		if (cachedTransitInfo != null) {
+			log.debug("Using cached TransitInfo for complexId={}, pinPointId={}", id, pinPointId);
+			return cachedTransitInfo;
 		}
 
-		/// 캐시가 없으면 템플릿 메서드를 사용하여 경로 계산
+		/// 상세조회 캐시가 없으면 경로를 다시 계산해 색상 포함 응답을 생성한다.
 		return calculateTransitRoute(id, pinPointId, pathResult -> {
 			RootResult rootResult = mapper.selectBest(pathResult);
+			TransitInfoResponse transitInfo = mapper.toTransitInfoResponse(rootResult);
 
-			/// RootResult를 Redis에 캐싱
+			/// 기존 공고/비교 화면 재사용을 위해 RootResult도 함께 캐싱한다.
 			distanceCacheService.cacheRootResult(id, pinPointId, rootResult);
+			distanceCacheService.cacheTransitInfo(id, pinPointId, transitInfo);
 
-			return mapper.toTransitInfoResponse(rootResult);
+			return transitInfo;
 		});
 	}
 
-	/// Segment 리스트 조회 (임대주택 상세조회용) - Deprecated, use getTransitInfo instead
-	@Deprecated
-	@Transactional(readOnly = true, noRollbackFor = CustomException.class)
-	public List<TransitRoutesResponse.SegmentResponse> getSegments(String id, String pinPointId) throws
-		UnsupportedEncodingException {
-		return calculateTransitRoute(id, pinPointId, pathResult -> {
-			RootResult rootResult = mapper.selectBest(pathResult);
-			return mapper.toSegmentResponses(rootResult);
-		});
-	}
-
-	/// 간편 대중교통 시뮬레이터
+	/// 공고/비교 화면에서 아직 사용하는 구 스키마.
+	/// 현재 호출부는 대부분 totalTimeMinutes만 사용하므로, 신규 화면은 getTransitInfo/getDistanceV2로 유지한다.
 	@Override
 	@Transactional(readOnly = true, noRollbackFor = CustomException.class)
 	public DistanceResponse getEasyDistance(String id, String pinPointId) throws UnsupportedEncodingException {
@@ -553,9 +545,11 @@ public class ComplexService implements ComplexUseCase {
 		/// 캐시가 없으면 템플릿 메서드를 사용하여 경로 계산
 		DistanceResponse distance = calculateTransitRoute(id, pinPointId, pathResult -> {
 			RootResult rootResult = mapper.selectBest(pathResult);
+			TransitInfoResponse transitInfo = mapper.toTransitInfoResponse(rootResult);
 
 			/// RootResult를 Redis에 캐싱
 			distanceCacheService.cacheRootResult(id, pinPointId, rootResult);
+			distanceCacheService.cacheTransitInfo(id, pinPointId, transitInfo);
 
 			List<DistanceResponse.TransitResponse> routes = mapper.from(rootResult);
 			return DistanceResponse.from(rootResult, routes);

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/service/DistanceCacheService.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/service/DistanceCacheService.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import co.kr.pinhouse.domain.housing.complex.application.dto.response.TransitInfoResponse;
 import co.kr.pinhouse.domain.housing.complex.domain.transit.RootResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DistanceCacheService {
 
 	private static final String ROOT_RESULT_PREFIX = "rootresult:";
+	private static final String TRANSIT_INFO_PREFIX = "transitinfo:";
 	private static final long CACHE_TTL_HOURS = 24;
 	private final RedisTemplate<String, Object> redisTemplate;
 
@@ -33,6 +35,10 @@ public class DistanceCacheService {
 	 */
 	private String generateRootResultKey(String complexId, String pinPointId) {
 		return ROOT_RESULT_PREFIX + complexId + ":" + pinPointId;
+	}
+
+	private String generateTransitInfoKey(String complexId, String pinPointId) {
+		return TRANSIT_INFO_PREFIX + complexId + ":" + pinPointId;
 	}
 
 	/**
@@ -76,6 +82,46 @@ public class DistanceCacheService {
 	}
 
 	/**
+	 * 상세조회용 TransitInfoResponse 캐시에 저장
+	 * @param complexId 단지 ID
+	 * @param pinPointId 핀포인트 ID
+	 * @param transitInfo 상세조회용 교통 응답
+	 */
+	public void cacheTransitInfo(String complexId, String pinPointId, TransitInfoResponse transitInfo) {
+		try {
+			String key = generateTransitInfoKey(complexId, pinPointId);
+			redisTemplate.opsForValue().set(key, transitInfo, CACHE_TTL_HOURS, TimeUnit.HOURS);
+			log.debug("Cached TransitInfo for complexId={}, pinPointId={}", complexId, pinPointId);
+		} catch (Exception e) {
+			log.error("Failed to cache TransitInfo: complexId={}, pinPointId={}", complexId, pinPointId, e);
+		}
+	}
+
+	/**
+	 * 상세조회용 TransitInfoResponse 조회
+	 * @param complexId 단지 ID
+	 * @param pinPointId 핀포인트 ID
+	 * @return 캐시된 TransitInfoResponse, 없으면 null
+	 */
+	public TransitInfoResponse getTransitInfo(String complexId, String pinPointId) {
+		try {
+			String key = generateTransitInfoKey(complexId, pinPointId);
+			Object cached = redisTemplate.opsForValue().get(key);
+
+			if (cached instanceof TransitInfoResponse) {
+				log.debug("TransitInfo cache hit for complexId={}, pinPointId={}", complexId, pinPointId);
+				return (TransitInfoResponse)cached;
+			}
+
+			log.debug("TransitInfo cache miss for complexId={}, pinPointId={}", complexId, pinPointId);
+			return null;
+		} catch (Exception e) {
+			log.error("Failed to get cached TransitInfo: complexId={}, pinPointId={}", complexId, pinPointId, e);
+			return null;
+		}
+	}
+
+	/**
 	 * 특정 RootResult 캐시 삭제
 	 * @param complexId 단지 ID
 	 * @param pinPointId 핀포인트 ID
@@ -84,6 +130,7 @@ public class DistanceCacheService {
 		try {
 			String key = generateRootResultKey(complexId, pinPointId);
 			redisTemplate.delete(key);
+			redisTemplate.delete(generateTransitInfoKey(complexId, pinPointId));
 			log.debug("Evicted RootResult cache for complexId={}, pinPointId={}", complexId, pinPointId);
 		} catch (Exception e) {
 			log.error("Failed to evict RootResult cache: complexId={}, pinPointId={}", complexId, pinPointId, e);

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/InterCityResultParser.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/InterCityResultParser.java
@@ -2,12 +2,17 @@ package co.kr.pinhouse.domain.housing.complex.application.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import co.kr.pinhouse.domain.housing.complex.domain.transit.BusRouteType;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.ExpressBusType;
 import co.kr.pinhouse.domain.housing.complex.domain.transit.InterCityResult;
 import co.kr.pinhouse.domain.housing.complex.domain.transit.LineInfo;
 import co.kr.pinhouse.domain.housing.complex.domain.transit.RootResult;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.SubwayLineType;
 import co.kr.pinhouse.domain.housing.complex.domain.transit.TrainType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -61,36 +66,74 @@ public class InterCityResultParser {
 						RootResult.TransportType transportType = RootResult.TransportType.fromTrafficType(trafficType);
 
 						String lineInfo = null;
+						SubwayLineType subwayLine = null;
+						BusRouteType busRouteType = null;
 						TrainType trainTypeEnum = null;
+						ExpressBusType expressBusType = null;
+						JsonNode lane = sub.path("lane");
+						JsonNode firstLane =
+							(lane.isArray() && !lane.isEmpty())
+								? lane.get(0)
+								: null;
 
-						if (transportType == RootResult.TransportType.TRAIN) {
+						// 도시간 응답이라도 첫/마지막 구간은 지하철/시내버스인 경우가 많다.
+						// 색상/라벨을 유지하려면 교통수단별 세부 메타데이터를 여기서 같이 채워야 한다.
+						if (transportType == RootResult.TransportType.SUBWAY && firstLane != null) {
+							lineInfo = joinField(lane, "name");
+							if (lineInfo != null
+								&& !lineInfo.endsWith("호선")
+								&& lineInfo.chars()
+								.allMatch(ch -> Character.isDigit(ch) || ch == ',' || ch == ' ')) {
+								lineInfo = addSuffixForEachNumber(lineInfo, "호선");
+							}
+							subwayLine = SubwayLineType.from(safeText(firstLane, "subwayCode"));
+						} else if (transportType == RootResult.TransportType.TRAIN) {
 							int trainTypeCode = sub.path("trainType").asInt(-1);
 							trainTypeEnum = TrainType.from(trainTypeCode);
-							lineInfo = trainTypeEnum.getLabel();
-						} else if (transportType == RootResult.TransportType.BUS) {
-							// 5: 고속, 6: 시외
-							lineInfo = (trafficType == 5) ? "고속버스" : "시외버스";
+							lineInfo =
+								(trainTypeEnum != TrainType.UNKNOWN)
+									? trainTypeEnum.getLabel()
+									: joinField(lane, "name");
+						} else if (transportType == RootResult.TransportType.BUS && firstLane != null) {
+							if (trafficType == 5 || trafficType == 6) {
+								String expressBusTypeStr = safeText(firstLane, "type");
+								expressBusType = parseExpressBusType(expressBusTypeStr);
+								lineInfo = (trafficType == 5) ? "고속버스" : "시외버스";
+							} else {
+								lineInfo = joinField(lane, "busNo");
+								busRouteType = BusRouteType.from(safeText(firstLane, "type"));
+							}
 						} else if (transportType == RootResult.TransportType.AIR) {
-							lineInfo = "항공";
+							lineInfo = joinField(lane, "name");
+							if (lineInfo == null) {
+								lineInfo = "항공";
+							}
 						}
 
 						// LineInfo 생성
 						LineInfo line = null;
-						if (trainTypeEnum != null) {
+						if (subwayLine != null) {
+							line = subwayLine.toLineInfo();
+						} else if (busRouteType != null) {
+							line = busRouteType.toLineInfo();
+						} else if (expressBusType != null) {
+							line = expressBusType.toLineInfo();
+						} else if (trainTypeEnum != null) {
 							line = trainTypeEnum.toLineInfo();
 						}
 
 						steps.add(RootResult.DistanceStep.builder()
 							.type(transportType)
 							.time(sub.path("sectionTime").asInt(0))
+							.distance(sub.path("distance").asInt(0))
 							.startName(sub.path("startName").asText(null))
 							.endName(sub.path("endName").asText(null))
 							.lineInfo(lineInfo)
 							.line(line)
-							.subwayLine(null)
-							.busRouteType(null)
+							.subwayLine(subwayLine)
+							.busRouteType(busRouteType)
 							.trainType(trainTypeEnum)
-							.expressBusType(null) // TODO: 필요 시 고속/시외버스 좌석 등급 파싱 추가
+							.expressBusType(expressBusType)
 							.build());
 					}
 				}
@@ -123,6 +166,53 @@ public class InterCityResultParser {
 	// =================
 	//  내부 로직
 	// =================
-	// 이전의 mapTransportType과 mapTrainType 메서드는 제거됨
-	// TransportType.fromTrafficType()과 TrainType.from()을 직접 사용
+
+	private static String joinField(JsonNode arrayNode, String field) {
+		var list = new ArrayList<String>();
+		arrayNode.forEach(node -> {
+			String value = node.path(field).asText(null);
+			if (value != null && !value.isBlank()) {
+				list.add(value);
+			}
+		});
+		if (list.isEmpty()) {
+			return null;
+		}
+		return list.stream()
+			.filter(Objects::nonNull)
+			.distinct()
+			.collect(Collectors.joining(", "));
+	}
+
+	private static String addSuffixForEachNumber(String text, String suffix) {
+		var parts = text.split(",");
+		for (int i = 0; i < parts.length; i++) {
+			String part = parts[i].trim();
+			if (part.chars().allMatch(Character::isDigit)) {
+				parts[i] = part + suffix;
+			} else {
+				parts[i] = part;
+			}
+		}
+		return String.join(", ", parts);
+	}
+
+	private static ExpressBusType parseExpressBusType(String code) {
+		if (code == null || code.isBlank()) {
+			return ExpressBusType.UNKNOWN;
+		}
+		try {
+			return ExpressBusType.from(Integer.parseInt(code.trim()));
+		} catch (NumberFormatException e) {
+			return ExpressBusType.UNKNOWN;
+		}
+	}
+
+	private static String safeText(JsonNode node, String field) {
+		if (node == null || !node.has(field)) {
+			return null;
+		}
+		String value = node.path(field).asText(null);
+		return (value == null || value.isBlank()) ? null : value;
+	}
 }

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/TransitResponseMapper.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/TransitResponseMapper.java
@@ -121,7 +121,8 @@ public class TransitResponseMapper {
 			.toList();
 	}
 
-	/// 출력을 위한 매퍼
+	/// 구 스키마 DistanceResponse용 매퍼.
+	/// 공고/비교 화면이 getEasyDistance에 의존하는 동안만 유지된다.
 	public List<DistanceResponse.TransitResponse> from(RootResult route) {
 
 		/// 출력할 값 리스트
@@ -238,7 +239,8 @@ public class TransitResponseMapper {
 	}
 
 	/**
-	 * TransitInfoResponse 생성 (전체 경로 정보 + 구간별 정보)
+	 * 상세조회용 요약 응답 생성.
+	 * 상위 1개 경로만 골라 총 시간/거리와 색 막대 렌더링용 segments만 만든다.
 	 */
 	public TransitInfoResponse toTransitInfoResponse(RootResult route) {
 		if (route == null) {
@@ -263,6 +265,7 @@ public class TransitResponseMapper {
 
 	/**
 	 * Segments 생성 (색 막대용)
+	 * Complex 상세조회와 TransitRoutesResponse가 공통으로 사용하므로 색상 계산 규칙을 한 곳에 모아둔다.
 	 */
 	public List<TransitRoutesResponse.SegmentResponse> toSegmentResponses(RootResult route) {
 		if (route == null || route.steps() == null) {

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/TransportColorResolver.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/application/util/TransportColorResolver.java
@@ -32,6 +32,11 @@ public final class TransportColorResolver {
 			return type.defaultBg;
 		}
 
+		// 파서가 LineInfo에 색상을 채운 경우 이를 우선 사용
+		if (step.line() != null && step.line().bgColorHex() != null && !step.line().bgColorHex().isBlank()) {
+			return step.line().bgColorHex();
+		}
+
 		// SUBWAY: subwayLine enum의 색상 사용
 		if (type == ChipType.SUBWAY) {
 			if (step.subwayLine() != null) {

--- a/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/domain/transit/RootResult.java
+++ b/module-domain/src/main/java/co/kr/pinhouse/domain/housing/complex/domain/transit/RootResult.java
@@ -1,18 +1,10 @@
 package co.kr.pinhouse.domain.housing.complex.domain.transit;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import co.kr.pinhouse.common.exception.code.ComplexErrorCode;
-import co.kr.pinhouse.common.response.CustomException;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Builder
 @Schema(name = "[응답][거리] 거리 및 이동 정보 응답", description = "총 소요 시간, 총 요금, 환승 횟수 등을 포함한 거리 응답 DTO입니다.")
 public record RootResult(
@@ -29,78 +21,6 @@ public record RootResult(
 	@Schema(description = "구간별 이동 단계 리스트")
 	List<DistanceStep> steps
 ) {
-
-	/// 정적 팩토리 메서드
-	public static List<RootResult> of(String json) {
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode root = mapper.readTree(json);
-
-			List<RootResult> responses = new ArrayList<>();
-			for (JsonNode pathNode : root.path("result").path("path")) {
-				JsonNode info = pathNode.path("info");
-
-				// steps 변환
-				List<DistanceStep> steps = new ArrayList<>();
-				for (JsonNode sub : pathNode.path("subPath")) {
-					int trafficType = sub.path("trafficType").asInt();
-					TransportType type = TransportType.fromTrafficType(trafficType);
-
-					String lineInfo = null;
-					SubwayLineType subwayLine = null;
-					BusRouteType busRouteType = null;
-
-					if (type == TransportType.BUS && sub.has("lane")) {
-						lineInfo = sub.path("lane").get(0).path("busNo").asText();
-						String busTypeStr = sub.path("lane").get(0).path("type").asText(null);
-						busRouteType = BusRouteType.from(busTypeStr);
-					} else if (type == TransportType.SUBWAY && sub.has("lane")) {
-						lineInfo = sub.path("lane").get(0).path("name").asText();
-						String subwayCodeStr = sub.path("lane").get(0).path("subwayCode").asText(null);
-						subwayLine = SubwayLineType.from(subwayCodeStr);
-					}
-
-					// LineInfo 생성
-					LineInfo line = null;
-					if (subwayLine != null) {
-						line = subwayLine.toLineInfo();
-					} else if (busRouteType != null) {
-						line = busRouteType.toLineInfo();
-					}
-
-					steps.add(DistanceStep.builder()
-						.type(type)
-						.time(sub.path("sectionTime").asInt())
-						.distance(sub.path("distance").asInt())
-						.startName(sub.path("startName").asText(null))
-						.endName(sub.path("endName").asText(null))
-						.lineInfo(lineInfo)
-						.line(line)
-						.subwayLine(subwayLine)
-						.busRouteType(busRouteType)
-						.trainType(null)
-						.expressBusType(null)
-						.build());
-				}
-
-				/// ODsay info.totalDistance 사용
-				int totalDistance = info.path("totalDistance").asInt(0);
-
-				RootResult response = RootResult.builder()
-					.totalTime(info.path("totalTime").asInt())
-					.totalPayment(info.path("payment").asInt())
-					.totalDistance(totalDistance)
-					.steps(steps)
-					.build();
-
-				responses.add(response);
-			}
-			return responses;
-		} catch (Exception e) {
-			throw new CustomException(ComplexErrorCode.ODSAY_PARSING_ERROR);
-		}
-
-	}
 
 	public enum TransportType {
 		WALK, BUS, SUBWAY, TRAIN, AIR, UNKNOWN;
@@ -148,6 +68,7 @@ public record RootResult(
 		@Schema(description = "통합 노선 정보 (코드, 이름, 색상)")
 		LineInfo line,
 
+		// 아래 메타 필드는 응답 직렬화용이 아니라 색상/라벨 계산을 위한 내부 보조 데이터입니다.
 		@Schema(hidden = true)
 		@com.fasterxml.jackson.annotation.JsonIgnore
 		SubwayLineType subwayLine,

--- a/module-domain/src/test/java/co/kr/pinhouse/domain/housing/complex/application/util/InterCityResultParserTest.java
+++ b/module-domain/src/test/java/co/kr/pinhouse/domain/housing/complex/application/util/InterCityResultParserTest.java
@@ -1,0 +1,113 @@
+package co.kr.pinhouse.domain.housing.complex.application.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import co.kr.pinhouse.domain.housing.complex.application.dto.response.ChipType;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.BusRouteType;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.ExpressBusType;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.InterCityResult;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.LineInfo;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.RootResult;
+import co.kr.pinhouse.domain.housing.complex.domain.transit.SubwayLineType;
+
+class InterCityResultParserTest {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final TransitResponseMapper mapper = new TransitResponseMapper();
+
+	@Test
+	void parse_mixedInterCityRoute_keepsTransportMetadataForSegmentColors() throws Exception {
+		String json = "{"
+			+ "\"result\":{"
+			+ "\"searchType\":1,"
+			+ "\"busCount\":1,"
+			+ "\"trainCount\":0,"
+			+ "\"airCount\":0,"
+			+ "\"mixedCount\":1,"
+			+ "\"path\":[{"
+			+ "\"info\":{"
+			+ "\"totalTime\":82,"
+			+ "\"totalPayment\":4500,"
+			+ "\"totalDistance\":42000"
+			+ "},"
+			+ "\"subPath\":["
+			+ "{"
+			+ "\"trafficType\":1,"
+			+ "\"sectionTime\":12,"
+			+ "\"distance\":6000,"
+			+ "\"startName\":\"서울역\","
+			+ "\"endName\":\"고속터미널\","
+			+ "\"lane\":[{"
+			+ "\"name\":\"1\","
+			+ "\"subwayCode\":\"1\""
+			+ "}]"
+			+ "},"
+			+ "{"
+			+ "\"trafficType\":2,"
+			+ "\"sectionTime\":18,"
+			+ "\"distance\":8500,"
+			+ "\"startName\":\"고속터미널\","
+			+ "\"endName\":\"서울경부\","
+			+ "\"lane\":[{"
+			+ "\"busNo\":\"9401\","
+			+ "\"type\":\"14\""
+			+ "}]"
+			+ "},"
+			+ "{"
+			+ "\"trafficType\":5,"
+			+ "\"sectionTime\":52,"
+			+ "\"distance\":27500,"
+			+ "\"startName\":\"서울경부\","
+			+ "\"endName\":\"천안종합터미널\","
+			+ "\"lane\":[{"
+			+ "\"type\":\"2\""
+			+ "}]"
+			+ "}"
+			+ "]"
+			+ "}]"
+			+ "}"
+			+ "}";
+
+		InterCityResult result = InterCityResultParser.parse(OBJECT_MAPPER.readTree(json));
+
+		assertThat(result.routes()).hasSize(1);
+		RootResult route = result.routes().getFirst();
+		assertThat(route.steps()).hasSize(3);
+
+		RootResult.DistanceStep subwayStep = route.steps().get(0);
+		assertThat(subwayStep.subwayLine()).isEqualTo(SubwayLineType.SEOUL_LINE_1);
+		assertThat(subwayStep.line().bgColorHex()).isEqualTo("#3356B4");
+
+		RootResult.DistanceStep busStep = route.steps().get(1);
+		assertThat(busStep.busRouteType()).isEqualTo(BusRouteType.WIDE_AREA);
+		assertThat(busStep.lineInfo()).isEqualTo("9401");
+
+		RootResult.DistanceStep expressBusStep = route.steps().get(2);
+		assertThat(expressBusStep.expressBusType()).isEqualTo(ExpressBusType.PREMIUM);
+		assertThat(expressBusStep.line().bgColorHex()).isEqualTo("#2E933C");
+
+		var segments = mapper.toSegmentResponses(route);
+		assertThat(segments)
+			.extracting(segment -> segment.colorHex())
+			.containsExactly("#3356B4", "#D82628", "#2E933C");
+	}
+
+	@Test
+	void extractBgColorHex_prefersLineColorWhenEnumSpecificFieldIsMissing() {
+		RootResult.DistanceStep step = RootResult.DistanceStep.builder()
+			.type(RootResult.TransportType.BUS)
+			.time(10)
+			.distance(5000)
+			.line(LineInfo.of(999, "테스트", "#123456"))
+			.build();
+
+		String color = TransportColorResolver.extractBgColorHex(step, ChipType.BUS);
+
+		assertThat(color).isEqualTo("#123456");
+	}
+}

--- a/module-infrastructure/src/main/java/co/kr/pinhouse/infrastructure/housing/complex/external/OdsayUtil.java
+++ b/module-infrastructure/src/main/java/co/kr/pinhouse/infrastructure/housing/complex/external/OdsayUtil.java
@@ -94,7 +94,9 @@ public class OdsayUtil implements DistanceUtil {
 	//  내부 로직
 	// =================
 
-	/// 응답의 도시내/ 도시간 기반 판별.
+	/// 응답의 도시내/도시간 기반 판별.
+	/// searchType=1/2인 도시간 경로도 세부 subPath에는 지하철/시내버스가 섞여 들어올 수 있으므로,
+	/// 개별 교통수단이 아니라 최상위 result 기준으로 파서를 결정한다.
 	private int detectSearchType(JsonNode root) {
 		JsonNode result = root.path("result");
 


### PR DESCRIPTION
## 📌 작업한 내용
- 프론트엔드에서 대중교통 타입별 색상 매핑 정상화

## 🖼️ 스크린샷
<img width="366" height="787" alt="image" src="https://github.com/user-attachments/assets/d16ec721-b0e9-4156-879b-179ae72ccc37" />


## 🔗 관련 이슈
#119 (외부 API 예외 처리 개선 - 연계)

## 체크리스트
- 로컬에서 임대주택 조회 테스트 완료
- 색상 매핑 테이블 검증
- 프론트엔드 렌더링 정상 확인
- 코드 리뷰 반영 완료