### PR TITLE
fix: 개발용 스웨거 주소 오류 수정 (#15)

### DIFF
--- a/module-infrastructure/src/main/java/co/kr/pinhouse/common/config/swagger/SwaggerConfig.java
+++ b/module-infrastructure/src/main/java/co/kr/pinhouse/common/config/swagger/SwaggerConfig.java
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.models.media.Schema;
 
 @Configuration
 @Profile("dev")
-@OpenAPIDefinition(servers = {@Server(url = "https://api.pinhouse.cloud", description = "PinHouse 개발 서버")})
+@OpenAPIDefinition(servers = {@Server(url = "https://api.dev.pinhouse.co.kr", description = "PinHouse 개발 서버")})
 public class SwaggerConfig {
 
 	@Bean


### PR DESCRIPTION
## 📌 작업한 내용
- 개발 환경에서 Swagger UI 접근 주소가 올바르게 동작하도록 수정
- 요청 호스트/포트 기준으로 Swagger base URL 및 redirect 경로 정정

## 🔍 참고 사항
- 개발 서버 접속 주소가 dev 도메인일 때 Swagger가 해당 환경 기준으로 열리도록 조정
- `swagger-ui/index.html`, `v3/api-docs` 경로 매핑 및 보안 허용 경로 확인 필요

## 🖼️ 스크린샷

## 🔗 관련 이슈
#15

## ✅ 체크리스트
- 개발 환경 Swagger 접속 확인
- `swagger-ui/index.html` 정상 노출 확인
- `v3/api-docs` 응답 확인
- 코드 리뷰 반영 완료